### PR TITLE
haiku: Read CPU model using get_cpu_model_string()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -395,7 +395,9 @@ test_run_tests_LDFLAGS += -lutil
 endif
 
 if HAIKU
-libuv_la_SOURCES += src/unix/haiku.c
+libuv_la_CFLAGS += -D_BSD_SOURCE
+libuv_la_SOURCES += src/unix/bsd-ifaddrs.c \
+                    src/unix/haiku.c
 endif
 
 if HURD

--- a/Makefile.am
+++ b/Makefile.am
@@ -398,7 +398,10 @@ if HAIKU
 libuv_la_CFLAGS += -D_BSD_SOURCE
 libuv_la_SOURCES += src/unix/bsd-ifaddrs.c \
                     src/unix/haiku.c \
-                    src/unix/no-proctitle.c
+                    src/unix/no-fsevents.c \
+                    src/unix/no-proctitle.c \
+                    src/unix/posix-hrtime.c \
+                    src/unix/posix-poll.c
 endif
 
 if HURD

--- a/Makefile.am
+++ b/Makefile.am
@@ -397,7 +397,8 @@ endif
 if HAIKU
 libuv_la_CFLAGS += -D_BSD_SOURCE
 libuv_la_SOURCES += src/unix/bsd-ifaddrs.c \
-                    src/unix/haiku.c
+                    src/unix/haiku.c \
+                    src/unix/no-proctitle.c
 endif
 
 if HURD

--- a/Makefile.am
+++ b/Makefile.am
@@ -394,6 +394,10 @@ libuv_la_SOURCES += src/unix/bsd-ifaddrs.c \
 test_run_tests_LDFLAGS += -lutil
 endif
 
+if HAIKU
+libuv_la_SOURCES += src/unix/haiku.c
+endif
+
 if HURD
 uvinclude_HEADERS += include/uv/posix.h
 libuv_la_SOURCES += src/unix/no-fsevents.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -307,6 +307,10 @@ if AIX
 test_run_tests_CFLAGS += -D_ALL_SOURCE -D_XOPEN_SOURCE=500 -D_LINUX_SOURCE_COMPAT
 endif
 
+if HAIKU
+test_run_tests_CFLAGS += -D_BSD_SOURCE
+endif
+
 if LINUX
 test_run_tests_CFLAGS += -D_GNU_SOURCE
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -395,6 +395,7 @@ test_run_tests_LDFLAGS += -lutil
 endif
 
 if HAIKU
+uvinclude_HEADERS += include/uv/posix.h
 libuv_la_CFLAGS += -D_BSD_SOURCE
 libuv_la_SOURCES += src/unix/bsd-ifaddrs.c \
                     src/unix/haiku.c \

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,7 @@ AM_CONDITIONAL([CYGWIN],   [AS_CASE([$host_os],[cygwin*],       [true], [false])
 AM_CONDITIONAL([DARWIN],   [AS_CASE([$host_os],[darwin*],       [true], [false])])
 AM_CONDITIONAL([DRAGONFLY],[AS_CASE([$host_os],[dragonfly*],    [true], [false])])
 AM_CONDITIONAL([FREEBSD],  [AS_CASE([$host_os],[*freebsd*],     [true], [false])])
+AM_CONDITIONAL([HAIKU],    [AS_CASE([$host_os],[haiku],         [true], [false])])
 AM_CONDITIONAL([HURD],     [AS_CASE([$host_os],[gnu*],          [true], [false])])
 AM_CONDITIONAL([LINUX],    [AS_CASE([$host_os],[linux*],        [true], [false])])
 AM_CONDITIONAL([MSYS],     [AS_CASE([$host_os],[msys*],         [true], [false])])
@@ -70,6 +71,9 @@ AS_CASE([$host_os],[mingw*], [
 AS_CASE([$host_os], [netbsd*], [AC_CHECK_LIB([kvm], [kvm_open])])
 AS_CASE([$host_os], [kfreebsd*], [
     LIBS="$LIBS -lfreebsd-glue"
+])
+AS_CASE([$host_os], [haiku], [
+    LIBS="$LIBS -lnetwork"
 ])
 AC_CHECK_HEADERS([sys/ahafs_evProds.h])
 AC_CONFIG_FILES([Makefile libuv.pc])

--- a/include/uv/unix.h
+++ b/include/uv/unix.h
@@ -66,6 +66,8 @@
 # include "uv/posix.h"
 #elif defined(__GNU__)
 # include "uv/posix.h"
+#elif defined(__HAIKU__)
+# include "uv/posix.h"
 #endif
 
 #ifndef NI_MAXHOST

--- a/src/unix/bsd-ifaddrs.c
+++ b/src/unix/bsd-ifaddrs.c
@@ -56,7 +56,7 @@ static int uv__ifaddr_exclude(struct ifaddrs *ent, int exclude_type) {
   if (ent->ifa_addr->sa_family != PF_INET &&
       ent->ifa_addr->sa_family != PF_INET6)
     return 1;
-#elif defined(__OpenBSD__)
+#elif defined(__OpenBSD__) || defined(__HAIKU__)
   if (ent->ifa_addr->sa_family != PF_INET)
     return 1;
 #endif

--- a/src/unix/bsd-ifaddrs.c
+++ b/src/unix/bsd-ifaddrs.c
@@ -49,7 +49,8 @@ static int uv__ifaddr_exclude(struct ifaddrs *ent, int exclude_type) {
   if (exclude_type == UV__EXCLUDE_IFPHYS)
     return (ent->ifa_addr->sa_family != AF_LINK);
 #endif
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__) || \
+    defined(__HAIKU__)
   /*
    * On BSD getifaddrs returns information related to the raw underlying
    * devices.  We're not interested in this information.
@@ -60,7 +61,7 @@ static int uv__ifaddr_exclude(struct ifaddrs *ent, int exclude_type) {
   if (ent->ifa_addr->sa_family != PF_INET &&
       ent->ifa_addr->sa_family != PF_INET6)
     return 1;
-#elif defined(__OpenBSD__) || defined(__HAIKU__)
+#elif defined(__OpenBSD__)
   if (ent->ifa_addr->sa_family != PF_INET)
     return 1;
 #endif

--- a/src/unix/bsd-ifaddrs.c
+++ b/src/unix/bsd-ifaddrs.c
@@ -31,6 +31,10 @@
 #include <net/if_dl.h>
 #endif
 
+#if defined(__HAIKU__)
+#define IFF_RUNNING IFF_LINK
+#endif
+
 static int uv__ifaddr_exclude(struct ifaddrs *ent, int exclude_type) {
   if (!((ent->ifa_flags & IFF_UP) && (ent->ifa_flags & IFF_RUNNING)))
     return 1;

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -916,7 +916,7 @@ int uv_getrusage(uv_rusage_t* rusage) {
   rusage->ru_stime.tv_sec = usage.ru_stime.tv_sec;
   rusage->ru_stime.tv_usec = usage.ru_stime.tv_usec;
 
-#if !defined(__MVS__)
+#if !defined(__MVS__) && !defined(__HAIKU__)
   rusage->ru_maxrss = usage.ru_maxrss;
   rusage->ru_ixrss = usage.ru_ixrss;
   rusage->ru_idrss = usage.ru_idrss;
@@ -1348,6 +1348,7 @@ int uv_cpumask_size(void) {
 #endif
 }
 
+#if !defined(__HAIKU__)
 int uv_os_getpriority(uv_pid_t pid, int* priority) {
   int r;
 
@@ -1374,6 +1375,7 @@ int uv_os_setpriority(uv_pid_t pid, int priority) {
 
   return 0;
 }
+#endif
 
 
 int uv__getsockpeername(const uv_handle_t* handle,

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1348,7 +1348,7 @@ int uv_cpumask_size(void) {
 #endif
 }
 
-#if !defined(__HAIKU__)
+
 int uv_os_getpriority(uv_pid_t pid, int* priority) {
   int r;
 
@@ -1375,7 +1375,6 @@ int uv_os_setpriority(uv_pid_t pid, int priority) {
 
   return 0;
 }
-#endif
 
 
 int uv__getsockpeername(const uv_handle_t* handle,

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -549,7 +549,7 @@ int uv__nonblock_ioctl(int fd, int set) {
 }
 
 
-#if !defined(__CYGWIN__) && !defined(__MSYS__)
+#if !defined(__CYGWIN__) && !defined(__MSYS__) && !defined(__HAIKU__)
 int uv__cloexec_ioctl(int fd, int set) {
   int r;
 

--- a/src/unix/haiku.c
+++ b/src/unix/haiku.c
@@ -1,0 +1,83 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+#include "internal.h"
+
+#include <OS.h>
+
+/* (c) 2001, 2002, François Revol (mmu_man), released under the MIT license.
+ *
+ * The algorithm for conversion between BeOS priority and Unix nice was taken
+ * from Haiku's renice tool.
+ *
+ * BeOs priorities:
+ * Realtime  High  Default  Low Prio
+ * 120       99    10       1 (0 only for idle_thread)
+ *
+ * UNIX nice:
+ *           -20    0       19
+ */
+
+#define NZERO 0
+
+#define BZERO B_NORMAL_PRIORITY
+#define BMIN  (B_REAL_TIME_DISPLAY_PRIORITY - 1)
+#define BMAX  1
+
+/* returns an equivalent UNIX nice for a given BeOS priority. */
+static int priority_beos_to_unix(int priority) {
+  if (priority > BZERO)
+    return NZERO - ((priority - BZERO) * NZERO) / (BMIN - BZERO);
+  return NZERO + ((BZERO - priority) * (NZERO - 1)) / (BZERO - BMAX);
+}
+
+/* returns an equivalent BeOS priority for a given UNIX nice. */
+static int priority_unix_to_beos(int priority) {
+  if (priority > NZERO)
+    return BZERO - ((priority - NZERO) * (BZERO - BMAX)) / (NZERO - 1);
+  return BZERO + ((NZERO - priority) * (BMIN - BZERO)) / (NZERO);
+}
+
+int uv_os_getpriority(uv_pid_t pid, int* priority) {
+  thread_info tinfo;
+  status_t status;
+
+  if (priority == NULL)
+    return UV_EINVAL;
+
+  status = get_thread_info(pid, &tinfo);
+  if (status != B_OK)
+    return UV__ERR(status);
+
+  *priority = priority_beos_to_unix(tinfo.priority)
+  return 0;
+}
+
+int uv_os_setpriority(uv_pid_t pid, int priority) {
+  if (priority < UV_PRIORITY_HIGHEST || priority > UV_PRIORITY_LOW)
+    return UV_EINVAL;
+
+  status = set_thread_priority(pid, priority_unix_to_beos(priority));
+  if (status != B_OK)
+    return UV__ERR(status);
+
+  return 0;
+}

--- a/src/unix/haiku.c
+++ b/src/unix/haiku.c
@@ -104,7 +104,8 @@ int uv_exepath(char* buffer, size_t* size) {
   if (buffer == NULL || size == NULL || *size == 0)
     return UV_EINVAL;
 
-  status = find_path(B_APP_IMAGE_SYMBOL, B_FIND_PATH_IMAGE_PATH, NULL, buffer, size);
+  status = find_path(B_APP_IMAGE_SYMBOL, B_FIND_PATH_IMAGE_PATH, NULL, buffer,
+                     *size);
   if (status != B_OK)
     return UV__ERR(status);
 
@@ -144,7 +145,7 @@ int uv_resident_set_memory(size_t* rss) {
   status_t status;
   thread_info thread;
 
-  status = get_thread_info(find_thread(NULL), thread);
+  status = get_thread_info(find_thread(NULL), &thread);
   if (status != B_OK)
     return UV__ERR(status);
 
@@ -190,7 +191,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
     return UV__ERR(status);
   }
 
-  for (i = 0; i < topology_count; i++)
+  for (i = 0; i < (int)topology_count; i++)
     if (topology_infos[i].type == B_TOPOLOGY_CORE) {
       cpuspeed = topology_infos[i].data.core.default_frequency;
       break;

--- a/src/unix/haiku.c
+++ b/src/unix/haiku.c
@@ -21,7 +21,7 @@
 #include "uv.h"
 #include "internal.h"
 
-#include <string.h> /* strlen() */
+#include <string.h> /* strlcpy() */
 
 #include <FindDirectory.h> /* find_path() */
 #include <OS.h>
@@ -35,17 +35,22 @@ void uv_loadavg(double avg[3]) {
 
 
 int uv_exepath(char* buffer, size_t* size) {
+  char abspath[B_PATH_NAME_LENGTH];
   status_t status;
+  size_t abspath_len;
 
   if (buffer == NULL || size == NULL || *size == 0)
     return UV_EINVAL;
 
   status = find_path(B_APP_IMAGE_SYMBOL, B_FIND_PATH_IMAGE_PATH, NULL, buffer,
-                     *size);
+                     sizeof(abspath));
   if (status != B_OK)
     return UV__ERR(status);
 
-  *size = strlen(buffer);
+  abspath_len = strlcpy(buffer, abspath, *size);
+  *size -= 1;
+  if (*size > abspath_len)
+    *size = abspath_len;
 
   return 0;
 }

--- a/src/unix/haiku.c
+++ b/src/unix/haiku.c
@@ -70,7 +70,7 @@ int uv_os_getpriority(uv_pid_t pid, int* priority) {
   if (status != B_OK)
     return UV__ERR(status);
 
-  *priority = priority_beos_to_unix(tinfo.priority);
+  *priority = beos_to_uv_priority(tinfo.priority);
   return 0;
 }
 
@@ -80,7 +80,7 @@ int uv_os_setpriority(uv_pid_t pid, int priority) {
   if (priority < UV_PRIORITY_HIGHEST || priority > UV_PRIORITY_LOW)
     return UV_EINVAL;
 
-  status = set_thread_priority(pid, priority_unix_to_beos(priority));
+  status = set_thread_priority(pid, uv_to_beos_priority(priority));
   if (status != B_OK)
     return UV__ERR(status);
 

--- a/src/unix/haiku.c
+++ b/src/unix/haiku.c
@@ -54,7 +54,7 @@ static int uv_to_beos_priority(int priority) {
   if (priority < UV_PRIORITY_NORMAL)
     return B_NORMAL_PRIORITY +
       (priority - UV_PRIORITY_NORMAL) *
-      (B_REAL_TIME_DISPLAY_PRIORITY - B_NORMAL_PRIORITY) /
+      (B_REAL_TIME_PRIORITY - B_NORMAL_PRIORITY) /
       (UV_PRIORITY_NORMAL - UV_PRIORITY_HIGHEST);
   return B_NORMAL_PRIORITY +
     (priority - UV_PRIORITY_NORMAL) *
@@ -63,13 +63,15 @@ static int uv_to_beos_priority(int priority) {
 }
 
 int uv_os_getpriority(uv_pid_t pid, int* priority) {
+  thread_id tid;
   thread_info tinfo;
   status_t status;
 
   if (priority == NULL)
     return UV_EINVAL;
 
-  status = get_thread_info(pid, &tinfo);
+  tid = pid == 0 ? find_thread(NULL) : pid;
+  status = get_thread_info(tid, &tinfo);
   if (status != B_OK)
     return UV__ERR(status);
 

--- a/src/unix/haiku.c
+++ b/src/unix/haiku.c
@@ -42,7 +42,7 @@ int uv_exepath(char* buffer, size_t* size) {
   if (buffer == NULL || size == NULL || *size == 0)
     return UV_EINVAL;
 
-  status = find_path(B_APP_IMAGE_SYMBOL, B_FIND_PATH_IMAGE_PATH, NULL, buffer,
+  status = find_path(B_APP_IMAGE_SYMBOL, B_FIND_PATH_IMAGE_PATH, NULL, abspath,
                      sizeof(abspath));
   if (status != B_OK)
     return UV__ERR(status);

--- a/src/unix/haiku.c
+++ b/src/unix/haiku.c
@@ -172,7 +172,6 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   system_info system;
   uint32_t topology_count;
   uint64_t cpuspeed;
-  uv_cpu_info_t* cpu;
 
   if (cpu_infos == NULL || count == NULL)
     return UV_EINVAL;
@@ -191,6 +190,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
     return UV__ERR(status);
   }
 
+  cpuspeed = 0;
   for (i = 0; i < (int)topology_count; i++)
     if (topology_infos[i].type == B_TOPOLOGY_CORE) {
       cpuspeed = topology_infos[i].data.core.default_frequency;
@@ -212,7 +212,7 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
   *count = system.cpu_count;
 
   /* CPU time is not exposed by Haiku, neither does the model name. */
-  for (i = 0; i < system.cpu_count; i++)
+  for (i = 0; i < (int)system.cpu_count; i++)
     (*cpu_infos)[i].speed = cpuspeed;
 
   return 0;

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -52,7 +52,7 @@ int uv_pipe_bind(uv_pipe_t* handle, const char* name) {
   name_len = strlen(name);
 
   if (name_len > sizeof(saddr.sun_path) - 1)
-    return -ENAMETOOLONG;
+    return UV_ENAMETOOLONG;
 
   /* Already bound? */
   if (uv__stream_fd(handle) >= 0)

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -420,6 +420,11 @@ static void uv__process_child_init(const uv_process_options_t* options,
     if (n == SIGKILL || n == SIGSTOP)
       continue;  /* Can't be changed. */
 
+#if defined(__HAIKU__)
+    if (n == SIGKILLTHR)
+      continue;  /* Can't be changed. */
+#endif
+
     if (SIG_ERR != signal(n, SIG_DFL))
       continue;
 

--- a/test/test-fs-copyfile.c
+++ b/test/test-fs-copyfile.c
@@ -25,7 +25,8 @@
 #include <fcntl.h>
 
 #if defined(__unix__) || defined(__POSIX__) || \
-    defined(__APPLE__) || defined(_AIX) || defined(__MVS__)
+    defined(__APPLE__) || defined(_AIX) || defined(__MVS__) || \
+    defined(__HAIKU__)
 #include <unistd.h> /* unlink, etc. */
 #else
 # include <direct.h>

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -1681,6 +1681,8 @@ TEST_IMPL(fs_chown) {
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(fchown_cb_count == 1);
 
+#ifndef __HAIKU__
+  /* Haiku doesn't support hardlink */
   /* sync link */
   r = uv_fs_link(NULL, &req, "test_file", "test_file_link", NULL);
   ASSERT(r == 0);
@@ -1698,6 +1700,7 @@ TEST_IMPL(fs_chown) {
   ASSERT(r == 0);
   uv_run(loop, UV_RUN_DEFAULT);
   ASSERT(lchown_cb_count == 1);
+#endif
 
   /* Close file */
   r = uv_fs_close(NULL, &req, file, NULL);

--- a/test/test-fs.c
+++ b/test/test-fs.c
@@ -31,7 +31,8 @@
 
 /* FIXME we shouldn't need to branch in this file */
 #if defined(__unix__) || defined(__POSIX__) || \
-    defined(__APPLE__) || defined(_AIX) || defined(__MVS__)
+    defined(__APPLE__) || defined(_AIX) || defined(__MVS__) || \
+    defined(__HAIKU__)
 #include <unistd.h> /* unlink, rmdir, etc. */
 #else
 # include <winioctl.h>


### PR DESCRIPTION
When running `make check`, the CPU model isn't read at all, and libuv crashes sometimes when uv_cpu_info() is used. This patch fixes these issues.

Before:
```
# uv_cpu_info:
#   model: (null)
```
After:
```
# uv_cpu_info:
#   model: Intel Core™ i5-2410M
```